### PR TITLE
Resolve plugins in install phase to decrease downloading activity in …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - openjdk8
 jobs:
   include:
-    install: skip
+    install: ./mvnw -q de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -Prelease
     script:
       - bash ./build.sh || travis_terminate 1;
     before_deploy: 'openssl aes-256-cbc


### PR DESCRIPTION
…script/deploy phase. Hopefully giving us less chatty travis logs!

Unfortunately will not `dependency:resolve` work as the reactor modules cannot be resolved as they havent been build yet.