### PR TITLE
Do not modify the content of remote request

### DIFF
--- a/troxy-server/src/main/java/no/sb1/troxy/util/SimulatorHandler.java
+++ b/troxy-server/src/main/java/no/sb1/troxy/util/SimulatorHandler.java
@@ -342,7 +342,7 @@ public class SimulatorHandler extends AbstractHandler {
                 && !"DELETE".equalsIgnoreCase(request.getMethod())
         ) {
             con.setDoOutput(true);
-            con.getOutputStream().write(request.getContent().getBytes(request.discoverCharset()));
+            con.getOutputStream().write(request.getRawByteContent());
             con.getOutputStream().close();
         }
         /* connect to webservice */


### PR DESCRIPTION
Previously we stored the contents of requests as strings. These strings
has to be created with a certain encoding. This introduces the
possibility of errors since we do not always now the encoding and
sometimes have to guess.

We solve this by storing the contents of the original request in two
different formats:
 1. As a byte array consisting of the unmodified bytes from the original request.
 2. As a String created from the bytes read.

The unmodified byte array is used when we pass on the request to remote
systems, while the String representation is used for request matching.

Also do some refactoring, mostly extracting private methods, in
Request.java.