### PR TITLE
REST API Configuration options: 

### DIFF
--- a/local/conf/troxy.properties
+++ b/local/conf/troxy.properties
@@ -22,6 +22,18 @@ troxy.mode=PLAYBACK
 troxy.allow_multiple_matching_recordings=false
 
 ################################################################################
+# REST API
+
+# Enable/Disable the REST API. Default is enabled
+troxy.restapi.enabled=true
+
+# List of hostnames to restrict where REST API is served. -If omitted or empty,
+# serve REST API on all hostnames. -This setting is useful for performance reasons
+# and in cases where the mocked system API overlaps with REST API (/api/*)
+# Valid values: comma-separated list; ex. localhost,troxy.test.acme.com
+troxy.restapi.hostnames=
+
+################################################################################
 # Statistics.
 
 # Interval between each statistics gathering in minutes.

--- a/troxy-server/src/main/java/no/sb1/troxy/rest/ApiHandler.java
+++ b/troxy-server/src/main/java/no/sb1/troxy/rest/ApiHandler.java
@@ -1,52 +1,31 @@
-package no.sb1.troxy.util;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+package no.sb1.troxy.rest;
 
 import no.sb1.troxy.Troxy;
 import no.sb1.troxy.common.Config;
 import no.sb1.troxy.http.common.Request;
 import no.sb1.troxy.record.v3.Recording;
 import no.sb1.troxy.record.v3.RequestPattern;
+import no.sb1.troxy.util.*;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Rest API for configuring and controlling Troxy.


### PR DESCRIPTION
troxy.restapi.enabled: Enable/Disable  REST API completely (default enabled)
troxy.restapi.hostnames: Specify list of virtualhosts for hosting the REST API (default all hosts)