### PR TITLE
Added support for sending client-side certificates in proxied requests

### DIFF
--- a/local/conf/troxy.properties
+++ b/local/conf/troxy.properties
@@ -44,7 +44,7 @@ statistics.interval=60
 
 
 ################################################################################
-# HTTP/HTTPS settings.
+# HTTP/HTTPS ingress settings (traffic terminated by troxy).
 
 http.port=8080
 #https.port=443
@@ -52,7 +52,20 @@ http.port=8080
 #https.keystore.type=JKS
 #https.keystore.password=PASSWORD
 #https.keystore.alias.key=identity
-#https.keystore.alias.password=PASSORD
+#https.keystore.alias.password=PASSWORD
+
+################################################################################
+# HTTP/HTTPS egress settings (traffic originated/proxied from troxy).
+
+egress.https.keystore.file=
+#egress.https.keystore.type=PKCS12
+#egress.https.keystore.password=PASSWORD
+#egress.https.keystore.alias.key=identity
+#egress.https.keystore.alias.password=PASSWORD
+
+# Force http requests to be proxied using https. -Default is false; proxy requests
+# using the incoming protocol (ex. http->http, https->https)
+egress.https.force=false
 
 
 ################################################################################

--- a/troxy-server/src/main/java/no/sb1/troxy/Troxy.java
+++ b/troxy-server/src/main/java/no/sb1/troxy/Troxy.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.ssl.AliasedX509ExtendedKeyManager;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -19,14 +20,15 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
@@ -88,6 +90,8 @@ public class Troxy implements Runnable {
     private TroxyFileHandler troxyFileHandler;
     private List<Class<Filter>> filterClasses = new ArrayList<>();
     private static TroxyJettyServer server;
+    private KeyManager[] proxyKeyManagers = null;
+    private boolean proxyForceHttps = false;
 
 
     /**
@@ -120,7 +124,8 @@ public class Troxy implements Runnable {
         /* set up server */
         server = new TroxyJettyServer(jettyConfig);
         loadFilters();
-
+        initProxySettings();
+        
         /* handlers */
         HandlerList handlerList = getHandlerList(cache);
 
@@ -198,6 +203,10 @@ public class Troxy implements Runnable {
     public String getLoadedRecordingsFile() {
         return loadedRecordingsFile;
     }
+
+    public KeyManager[] getProxyKeyManagers() { return proxyKeyManagers; }
+
+    public boolean isProxyForceHttps() { return proxyForceHttps; }
 
     /**
      * Get the list of filters that may be applied to requests/responses.
@@ -327,6 +336,7 @@ public class Troxy implements Runnable {
         mode = Mode.valueOf(config.getValue(KEY_MODE, DEFAULT_MODE.name()).toUpperCase());
         updateStatisticsInterval();
         loadFilters();
+        initProxySettings();
         return true;
     }
 
@@ -410,5 +420,42 @@ public class Troxy implements Runnable {
         }
         Collections.sort(filterClasses, (o1, o2) -> o1.getName().compareTo(o2.getName()));
         log.info("Filters will be executed in this order: {}", filterClasses.stream().map(Class::getName).collect(Collectors.joining(", ")));
+    }
+
+    private void initProxySettings() {
+        this.proxyForceHttps="true".equalsIgnoreCase(config.getValue("egress.https.force"));
+        this.proxyKeyManagers = initProxyKeyManagers();
+    }
+
+    private KeyManager[] initProxyKeyManagers() {
+        log.info("Loading client side certificates...");
+        KeyManager[] keyManager = null;
+        final String clientKeystoreLocation = config.getValue("egress.https.keystore.file");
+        if (clientKeystoreLocation == null || clientKeystoreLocation.isEmpty()) return null;
+
+        try {
+            KeyStore keyStore = KeyStore.getInstance(config.getValue("egress.https.keystore.type"));
+            FileInputStream fis = new FileInputStream(clientKeystoreLocation);
+
+            keyStore.load(fis, config.getValue("egress.https.keystore.password").toCharArray());
+
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
+            keyManagerFactory.init(keyStore, config.getValue("egress.https.keystore.alias.password").toCharArray());
+            keyManager = keyManagerFactory.getKeyManagers();
+
+            String alias = config.getValue("egress.https.keystore.alias.key");
+            if (alias != null && !alias.isEmpty()) {
+                for (int i = 0; i < keyManager.length; i++) {
+                    if (keyManager[i] instanceof X509ExtendedKeyManager) {
+                        keyManager[i] = new AliasedX509ExtendedKeyManager((X509ExtendedKeyManager) keyManager[i], alias);
+                    }
+                }
+            }
+        }
+        catch (Exception e) {
+            log.error("Failed loading client certificates",e);
+            throw new IllegalStateException("Unable to initialize client key manager", e);
+        }
+        return keyManager;
     }
 }

--- a/troxy-server/src/main/java/no/sb1/troxy/util/SimulatorHandler.java
+++ b/troxy-server/src/main/java/no/sb1/troxy/util/SimulatorHandler.java
@@ -1,27 +1,5 @@
 package no.sb1.troxy.util;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import no.sb1.troxy.Troxy;
 import no.sb1.troxy.common.Config;
 import no.sb1.troxy.common.Mode;
@@ -31,9 +9,25 @@ import no.sb1.troxy.http.common.Response;
 import no.sb1.troxy.record.v3.Recording;
 import no.sb1.troxy.record.v3.RequestPattern;
 import no.sb1.troxy.record.v3.ResponseTemplate;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import javax.net.ssl.*;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A handler for incoming requests.
@@ -315,11 +309,21 @@ public class SimulatorHandler extends AbstractHandler {
             simLog.debug("Unable to parse Request port as an Integer, setting port to 80");
             port = 80;
         }
-        URL url = new URL(request.getProtocol(), request.getHost(), port, pathAndQuery);
+        //Override protocol and port if proxyForceHttps is set
+        String protocol = troxy.isProxyForceHttps() ? "https" : request.getProtocol();
+        port = troxy.isProxyForceHttps() ? 443 : port;
+        URL url = new URL(protocol, request.getHost(), port, pathAndQuery);
+
         simLog.info("Connecting to host: {}", url);
         simLog.debug("Request header: {}", request.getHeader());
         simLog.debug("Request content: {}", request.getContent());
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        //Use client side certificate if provided
+        if (troxy.getProxyKeyManagers() != null && "https".equalsIgnoreCase(url.getProtocol())) {
+            HttpsURLConnection cons = (HttpsURLConnection) con;
+            simLog.info("Using custom SSL truststore: {}, alias: {} when forwarding request",config.getValue("egress.https.keystore.file"),config.getValue("egress.https.keystore.alias.key"));
+            cons.setSSLSocketFactory(createClientSSLContext().getSocketFactory());
+        }
         /* set method */
         con.setRequestMethod(request.getMethod());
         /* set headers */
@@ -350,6 +354,18 @@ public class SimulatorHandler extends AbstractHandler {
         con.connect();
 
         return con;
+    }
+
+    private SSLContext createClientSSLContext() {
+        KeyManager[] keyManager = null;
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            //TODO:Verify if works with default trustmanager and securerandom
+            sslContext.init(troxy.getProxyKeyManagers(), (TrustManager[]) Arrays.asList((TrustManager) new NoTrustManager()).toArray(), new java.security.SecureRandom());
+            return sslContext;
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to initialize client SSL context", e);
+        }
     }
 
     /**


### PR DESCRIPTION
TTSIA

*Added options for specifying client-side certificates to be used for proxying requests 

*Also added special option for supporting a http->https transition through troxy, thus making tcpdump a little more convenient in some circumstances