### PR TITLE
Add <name>-tag to pom.xml to fix Maven central deploy issue

### DIFF
--- a/troxy-embedded/pom.xml
+++ b/troxy-embedded/pom.xml
@@ -8,6 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>troxy-embedded</artifactId>
+    <name>Troxy Embedded</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Prøvar att fixa:

```
[ERROR] Nexus Staging Rules Failure Report
[ERROR] ==================================
[ERROR] 
[ERROR] Repository "nosparebank1-1023" failures
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /no/sparebank1/troxy/troxy-embedded/3.1.110/troxy-embedded-3.1.110.pom: Project name missing
[ERROR] 
[ERROR] 
```