### PR TITLE
Matches headers in AutoRegexNewRecording line by line instead of entire input at once

### DIFF
--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -19,5 +19,10 @@
       <groupId>no.sparebank1.troxy</groupId>
       <artifactId>troxy-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/filter/src/test/java/no/sb1/troxy/filter/AutoRegexNewRecordingTest.java
+++ b/filter/src/test/java/no/sb1/troxy/filter/AutoRegexNewRecordingTest.java
@@ -1,0 +1,282 @@
+package no.sb1.troxy.filter;
+
+import no.sb1.troxy.record.v3.Recording;
+import no.sb1.troxy.record.v3.RequestPattern;
+import no.sb1.troxy.record.v3.ResponseTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static no.sb1.troxy.record.v3.RequestPattern.escape;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class AutoRegexNewRecordingTest {
+    private static RequestPattern createRequestPattern() {
+        final RequestPattern requestPattern = new RequestPattern();
+        requestPattern.setHeader(
+                "^" + escape(
+                        "Accept: */*\n" +
+                                "Authorization: basic auth\n" +
+                                "Cache-Control: no-cache\n" +
+                                "Connection: close\n" +
+                                "Content-Length: 1850\n" +
+                                "Content-Type: text/xml; charset=UTF-8\n" +
+                                "Cookie: delicious-cookie\n" +
+                                "Forwarded: forwarded-for\n" +
+                                "Host: host\n" +
+                                "Pragma: no-cache\n" +
+                                "SOAPAction: \"soap-action\"\n" +
+                                "User-Agent: User-Agent\n" +
+                                "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                                "X-Forwarded-For: 12.123.123.12\n" +
+                                "X-Forwarded-Host: forwarded-host\n" +
+                                "X-Forwarded-Port: 443\n" +
+                                "X-Forwarded-Proto: https"
+                ) + "$");
+        return requestPattern;
+    }
+
+    private static RequestPattern createSimpleRequestPattern() {
+        final RequestPattern requestPattern = new RequestPattern();
+        requestPattern.setHeader(
+                "^" + escape("Host: nettbank") + "$");
+        return requestPattern;
+    }
+
+    @BeforeEach
+    void clearAutoRegexNewRecording() {
+        AutoRegexNewRecording.headerPatterns.clear();
+    }
+
+    @Test
+    @DisplayName("loadConfig should load pattern without replacement value when valid config entry does not contain semicolon")
+    void testLoadConfigWithoutReplacement() {
+        final String headerPatternKey = "header.accept";
+        final String headerPatternValue = "Accept: [^\\\\n]*";
+
+        final Map<String, Map<String, String>> config = new HashMap<>();
+        final Map<String, String> otherConfig = new HashMap<>();
+        otherConfig.put(headerPatternKey, headerPatternValue);
+        config.put(null, otherConfig);
+
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+        autoRegexNewRecording.loadConfig(config);
+
+        assertNull(AutoRegexNewRecording.headerPatterns.get(0).getReplacement());
+    }
+
+    @Test
+    @DisplayName("loadConfig should load pattern with replacement value when valid config entry contains semicolon")
+    void testLoadConfigWithReplacement() {
+        final String replacementValue = "Accept";
+        final String headerPatternKey = "header.accept";
+        final String headerPatternValue = "Accept: [^\\\\n]*;" + replacementValue;
+
+        final Map<String, Map<String, String>> config = new HashMap<>();
+        final Map<String, String> otherConfig = new HashMap<>();
+        otherConfig.put(headerPatternKey, headerPatternValue);
+        config.put(null, otherConfig);
+
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+        autoRegexNewRecording.loadConfig(config);
+
+        assertEquals(replacementValue, AutoRegexNewRecording.headerPatterns.get(0).getReplacement());
+    }
+
+    @Test
+    @DisplayName("loadConfig should load patterns according to config key")
+    void testLoadConfigOrder() {
+        final Map<String, Map<String, String>> config = new HashMap<>();
+        final Map<String, String> otherConfig = new HashMap<>();
+        otherConfig.put("header.xylophone", "fifth");
+        otherConfig.put("header.accept", "second");
+        otherConfig.put("header.bamse", "fourth");
+        otherConfig.put("header.aardvark", "first");
+        otherConfig.put("header.axolotl", "third");
+        config.put(null, otherConfig);
+
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+        autoRegexNewRecording.loadConfig(config);
+
+        assertEquals("first", AutoRegexNewRecording.headerPatterns.get(0).getPattern().pattern());
+        assertEquals("second", AutoRegexNewRecording.headerPatterns.get(1).getPattern().pattern());
+        assertEquals("third", AutoRegexNewRecording.headerPatterns.get(2).getPattern().pattern());
+        assertEquals("fourth", AutoRegexNewRecording.headerPatterns.get(3).getPattern().pattern());
+        assertEquals("fifth", AutoRegexNewRecording.headerPatterns.get(4).getPattern().pattern());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should match and replace one pattern at a time")
+    void testFilterNewRecordingOnebyOne() {
+        final RequestPattern requestPattern = createSimpleRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("first_key", Pattern.compile("^Host: nettbank"), "Host: schnettbank"));
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("second_key", Pattern.compile("^Host: schnettbank"), "Host: schpettbank"));
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader = "^Host: schpettbank$";
+
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should replace headers matching pattern with the pattern itself when no replacement was specified")
+    void testFilterNewRecordingWithoutReplacement() {
+        final RequestPattern requestPattern = createRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("key", Pattern.compile("SOAPAction: (?<action>\"[a-zA-Z_-]+\")"), "SOAPAction: $1.*"));
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader =
+                "^Accept: \\*/\\*\n" +
+                        "Authorization: basic auth\n" +
+                        "Cache-Control: no-cache\n" +
+                        "Connection: close\n" +
+                        "Content-Length: 1850\n" +
+                        "Content-Type: text/xml; charset=UTF-8\n" +
+                        "Cookie: delicious-cookie\n" +
+                        "Forwarded: forwarded-for\n" +
+                        "Host: host\n" +
+                        "Pragma: no-cache\n" +
+                        "SOAPAction: \"soap-action\".*\n" +
+                        "User-Agent: User-Agent\n" +
+                        "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                        "X-Forwarded-For: 12\\.123\\.123\\.12\n" +
+                        "X-Forwarded-Host: forwarded-host\n" +
+                        "X-Forwarded-Port: 443\n" +
+                        "X-Forwarded-Proto: https$";
+
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should replace headers matching pattern with replacement when replacement was specified")
+    void testFilterNewRecordingWithReplacement() {
+        final RequestPattern requestPattern = createRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("key", Pattern.compile("Accept: [^\\n]*"), "Accept: \"replaced value\""));
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader =
+                "^Accept: \"replaced value\"\n" +
+                        "Authorization: basic auth\n" +
+                        "Cache-Control: no-cache\n" +
+                        "Connection: close\n" +
+                        "Content-Length: 1850\n" +
+                        "Content-Type: text/xml; charset=UTF-8\n" +
+                        "Cookie: delicious-cookie\n" +
+                        "Forwarded: forwarded-for\n" +
+                        "Host: host\n" +
+                        "Pragma: no-cache\n" +
+                        "SOAPAction: \"soap-action\"\n" +
+                        "User-Agent: User-Agent\n" +
+                        "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                        "X-Forwarded-For: 12\\.123\\.123\\.12\n" +
+                        "X-Forwarded-Host: forwarded-host\n" +
+                        "X-Forwarded-Port: 443\n" +
+                        "X-Forwarded-Proto: https$";
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should replace all matches with pattern itself when pattern has multiple matches and replacement is not specified")
+    void testFilterNewRecordingMultipleMatchesWithoutReplacement() {
+        final RequestPattern requestPattern = createRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("key", Pattern.compile("Host: [^\\n]*"), null));
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader =
+                "^Accept: \\*/\\*\n" +
+                        "Authorization: basic auth\n" +
+                        "Cache-Control: no-cache\n" +
+                        "Connection: close\n" +
+                        "Content-Length: 1850\n" +
+                        "Content-Type: text/xml; charset=UTF-8\n" +
+                        "Cookie: delicious-cookie\n" +
+                        "Forwarded: forwarded-for\n" +
+                        "Host: [^\\n]*\n" +
+                        "Pragma: no-cache\n" +
+                        "SOAPAction: \"soap-action\"\n" +
+                        "User-Agent: User-Agent\n" +
+                        "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                        "X-Forwarded-For: 12\\.123\\.123\\.12\n" +
+                        "X-Forwarded-Host: [^\\n]*\n" +
+                        "X-Forwarded-Port: 443\n" +
+                        "X-Forwarded-Proto: https$";
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should replace all matches with replacement when pattern has multiple matches and replacement is specified")
+    void testFilterNewRecordingMultipleMatchesWithReplacement() {
+        final RequestPattern requestPattern = createRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        AutoRegexNewRecording.headerPatterns.add(new AutoRegexNewRecording.PatternWithReplacement("key", Pattern.compile("Host: [^\\n]*"), "Host: \"replaced value\""));
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader =
+                "^Accept: \\*/\\*\n" +
+                        "Authorization: basic auth\n" +
+                        "Cache-Control: no-cache\n" +
+                        "Connection: close\n" +
+                        "Content-Length: 1850\n" +
+                        "Content-Type: text/xml; charset=UTF-8\n" +
+                        "Cookie: delicious-cookie\n" +
+                        "Forwarded: forwarded-for\n" +
+                        "Host: \"replaced value\"\n" +
+                        "Pragma: no-cache\n" +
+                        "SOAPAction: \"soap-action\"\n" +
+                        "User-Agent: User-Agent\n" +
+                        "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                        "X-Forwarded-For: 12\\.123\\.123\\.12\n" +
+                        "X-Forwarded-Host: \"replaced value\"\n" +
+                        "X-Forwarded-Port: 443\n" +
+                        "X-Forwarded-Proto: https$";
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+
+    @Test
+    @DisplayName("filterNewRecording should not replace anything when no patterns are present")
+    void testFilterNewRecordingWithoutAnyPatterns() {
+        final RequestPattern requestPattern = createRequestPattern();
+        final Recording recording = new Recording(requestPattern, new ResponseTemplate());
+        final AutoRegexNewRecording autoRegexNewRecording = new AutoRegexNewRecording();
+        autoRegexNewRecording.filterNewRecording(recording);
+
+        final String expectedHeader =
+                "^Accept: \\*/\\*\n" +
+                        "Authorization: basic auth\n" +
+                        "Cache-Control: no-cache\n" +
+                        "Connection: close\n" +
+                        "Content-Length: 1850\n" +
+                        "Content-Type: text/xml; charset=UTF-8\n" +
+                        "Cookie: delicious-cookie\n" +
+                        "Forwarded: forwarded-for\n" +
+                        "Host: host\n" +
+                        "Pragma: no-cache\n" +
+                        "SOAPAction: \"soap-action\"\n" +
+                        "User-Agent: User-Agent\n" +
+                        "X-CACHE-BALANCE-HEADER: balance-header\n" +
+                        "X-Forwarded-For: 12\\.123\\.123\\.12\n" +
+                        "X-Forwarded-Host: forwarded-host\n" +
+                        "X-Forwarded-Port: 443\n" +
+                        "X-Forwarded-Proto: https$";
+        assertEquals(expectedHeader, requestPattern.getHeader());
+    }
+}

--- a/troxy-core/src/test/java/no/sb1/troxy/util/CacheTest.java
+++ b/troxy-core/src/test/java/no/sb1/troxy/util/CacheTest.java
@@ -6,10 +6,10 @@ import no.sb1.troxy.record.v3.RequestPattern;
 import no.sb1.troxy.record.v3.ResponseTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -22,40 +22,224 @@ class CacheTest {
         cache = Cache.createCacheRoot();
     }
 
+    private void putRecordingsInCache(String... paths) {
+        Cache.loadRecordings(
+                cache,
+                new TroxyFileHandler("src/test/java/no/sb1/troxy/util", ""),
+                new HashSet<>(Arrays.asList(paths))
+        );
+    }
+
     @Test
     void emptyCacheShouldReturnNothing() {
-        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", ""));
+        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", "", null));
         assertEquals(0, results.size());
     }
 
     @Test
     void matchWithOneEntry() {
-        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", ""));
-        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", ""));
+        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", "", null));
+        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", "", null));
         assertEquals(1, results.size());
     }
 
     @Test
     void noMatchWithOneEntry() {
-        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/path", ""));
-        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", ""));
+        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/path", "", null));
+        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", "", null));
         assertEquals(0, results.size());
     }
 
     @Test
-    @Disabled // find out about how pattern matching works
+    @Disabled
+        // find out about how pattern matching works
     void matchWithSeveralEntries() {
-        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", "a"));
-        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", "b"));
-        cache.addRecoding(testRecording("GET", "https", "example.com", "80", "/login", ""));
-        cache.addRecoding(testRecording("POST", "http", "example.com", "80", "/path", ""));
-        cache.addRecoding(testRecording("PUT", "http", "example.com", "80", "/path", ""));
+        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", "a", null));
+        cache.addRecoding(testRecording("GET", "http", "example.com", "80", "/", "b", null));
+        cache.addRecoding(testRecording("GET", "https", "example.com", "80", "/login", "", null));
+        cache.addRecoding(testRecording("POST", "http", "example.com", "80", "/path", "", null));
+        cache.addRecoding(testRecording("PUT", "http", "example.com", "80", "/path", "", null));
 
-        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", ""));
+        final List<Cache.Result> results = cache.searchCache(testRequest("GET", "http", "example.com", "80", "/", "", null));
         assertEquals(2, results.size());
     }
 
-    private Recording testRecording(final String method, final String protocol, final String host, final String port, final String path, final String content) {
+    @Test
+    @DisplayName("searchCache should return 1 result when all headers were present")
+    void testDefaultCase() {
+        putRecordingsInCache("test-recording.troxy");
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS";
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @DisplayName("searchCache should return 1 result when several recording were present in cache but only the one with the correct 'SOAPAction' matched")
+    void test2() {
+        putRecordingsInCache("test-recording.troxy", "test-recording-not-match.troxy");
+
+
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS";
+
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @DisplayName("searchCache should return 1 result when request matches, but has additional headers")
+    void testExtraHeaders() {
+        putRecordingsInCache("test-recording.troxy");
+
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Cookie: delicious-cookie\n" +
+                "Forwarded: forwarded-for\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS\n" +
+                "X-CACHE-BALANCE-HEADER: cache-balance-header\n" +
+                "X-Forwarded-For: forwarded-for\n" +
+                "X-Forwarded-Host: forwarded-host\n" +
+                "X-Forwarded-Port: 443\n" +
+                "X-Forwarded-Proto: https\n";
+
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @DisplayName("searchCache should return 0 results when mandatory headers 'Dingo' and 'X-XLast-Header' are not present on request")
+    void testMissingExtraHeaders() {
+        putRecordingsInCache("test-recording-with-extra-headers.troxy");
+
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Cookie: delicious-cookie\n" +
+                "Forwarded: forwarded-for\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS\n" +
+                "X-CACHE-BALANCE-HEADER: cache-balance-header\n" +
+                "X-Forwarded-For: forwarded-for\n" +
+                "X-Forwarded-Host: forwarded-host\n" +
+                "X-Forwarded-Port: 443\n" +
+                "X-Forwarded-Proto: https\n";
+
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    @DisplayName("searchCache should return 1 result when mandatory headers 'Dingo' and 'X-XLast-Header' are present on request")
+    void testExtraHeadersPresent() {
+        putRecordingsInCache("test-recording-with-extra-headers.troxy");
+
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Cookie: delicious-cookie\n" +
+                "Dingo: \"straya mate\"\n" +
+                "Forwarded: forwarded-for\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS\n" +
+                "X-CACHE-BALANCE-HEADER: cache-balance-header\n" +
+                "X-Forwarded-For: forwarded-for\n" +
+                "X-Forwarded-Host: forwarded-host\n" +
+                "X-Forwarded-Port: 443\n" +
+                "X-Forwarded-Proto: https\n" +
+                "X-XLast-Header: true\n";
+
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    @DisplayName("searchCache should return 0 results when mandatory headers 'Dingo' and 'X-XLast-Header' are present, but had the wrong value")
+    void testExtraHeadersPresentButWrongValue() {
+        putRecordingsInCache("test-recording-with-extra-headers.troxy");
+
+        final String requestHeader =
+                "Accept: */*\n" +
+                "Authorization: Basic authorization-123\n" +
+                "Cache-Control: no-cache\n" +
+                "Connection: close\n" +
+                "Content-Length: 1850\n" +
+                "Content-Type: text/xml; charset=UTF-8\n" +
+                "Cookie: delicious-cookie\n" +
+                "Dingo: \"kiwi mate\"\n" +
+                "Forwarded: forwarded-for\n" +
+                "Host: www.example.com\n" +
+                "Pragma: no-cache\n" +
+                "SOAPAction: \"my-soap-action\"\n" +
+                "User-Agent: User-Agent iOS\n" +
+                "X-CACHE-BALANCE-HEADER: cache-balance-header\n" +
+                "X-Forwarded-For: forwarded-for\n" +
+                "X-Forwarded-Host: forwarded-host\n" +
+                "X-Forwarded-Port: 443\n" +
+                "X-Forwarded-Proto: https\n" +
+                "X-XLast-Header: false\n";
+
+        final Request request = testRequest("POST", "https", "example.com", "443", "/example", "<>Content</>", requestHeader);
+
+        final List<Cache.Result> results = cache.searchCache(request);
+
+        assertEquals(0, results.size());
+    }
+
+    private Recording testRecording(final String method, final String protocol, final String host, final String port, final String path, final String content, final String header) {
         final Recording recording = new Recording();
         recording.setResponseStrategy(Recording.ResponseStrategy.SEQUENTIAL);
         final RequestPattern requestPattern = new RequestPattern();
@@ -64,19 +248,21 @@ class CacheTest {
         requestPattern.setHost(host);
         requestPattern.setPort(port);
         requestPattern.setPath(path);
+        requestPattern.setHeader(header);
         requestPattern.setContent(content);
         recording.setRequestPattern(requestPattern);
         recording.setResponseTemplates(Collections.singletonList(new ResponseTemplate()));
         return recording;
     }
 
-    private Request testRequest(final String method, final String protocol, final String host, final String port, final String path, final String content) {
+    private Request testRequest(final String method, final String protocol, final String host, final String port, final String path, final String content, final String header) {
         final Request request = new Request();
         request.setMethod(method);
         request.setProtocol(protocol);
         request.setHost(host);
         request.setPort(port);
         request.setPath(path);
+        request.setHeader(header);
         request.setContent(content);
 
         return request;

--- a/troxy-core/src/test/java/no/sb1/troxy/util/test-recording-not-match.troxy
+++ b/troxy-core/src/test/java/no/sb1/troxy/util/test-recording-not-match.troxy
@@ -1,0 +1,99 @@
+This is a Troxy recording file.
+You can modify this file in your editor of choice, but there are some rules you must follow:
+* All fields except "COMMENT", "HEADER" and "CONTENT" must stay in one line.
+* Everything after "=" for the fields will be included (text won't be trimmed), this includes whitespace.
+* The "[COMMENT<_END>]", "[HEADER<_END>]" and "[CONTENT<_END>]" markers must be the only text on their lines.
+* If the comment contains "[COMMENT_END]", this must be escaped as "[[COMMENT_END]]".
+* If the header contains "[HEADER_END]", this must be escaped as "[[HEADER_END]]".
+* If the content contains "[CONTENT_END]", this must be escaped as "[[CONTENT_END]]".
+* Any text outside a field will be ignored, and erased if recording is modified in the user interface.
+
+---RECORDING---
+[COMMENT]
+
+[COMMENT_END]
+RESPONSE_STRATEGY=SEQUENTIAL
+
+---REQUEST---
+PROTOCOL=^https$
+HOST=^.*$
+PORT=^443$
+PATH=^/example$
+QUERY=^$
+METHOD=^POST$
+[HEADER]
+^Accept: .*
+Authorization: .*
+Cache-Control: .*
+Connection: .*
+Content-Length: .*
+Content-Type: .*
+Host: .*
+Pragma: .*
+SOAPAction: "anotherAction".*
+User-Agent: .*$
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_REQUEST---
+PROTOCOL=https
+HOST=www.example.com
+PORT=443
+PATH=/example$
+QUERY=
+METHOD=POST
+[HEADER]
+Accept: */*
+Authorization: Basic authorization
+Cache-Control: no-cache
+Connection: close
+Content-Length: 1850
+Content-Type: text/xml; charset=UTF-8
+Cookie: delicious-cookie
+Forwarded: forwarded-for
+Host: host
+Pragma: no-cache
+SOAPAction: "anotherAction"
+User-Agent: User-Agent iOS
+X-CACHE-BALANCE-HEADER: cache-balance-header
+X-Forwarded-For: 12.123.123.12
+X-Forwarded-Host: forwarded-host
+X-Forwarded-Port: 443
+X-Forwarded-Proto: https
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---RESPONSE---
+DELAY_STRATEGY=NONE
+DELAY_MIN=0
+DELAY_MEAN=0
+DELAY_MAX=0
+WEIGHT=1
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 1 Jan 1970 00:00:00 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_RESPONSE---
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 26 Oct 2020 12:58:54 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]

--- a/troxy-core/src/test/java/no/sb1/troxy/util/test-recording-with-extra-headers.troxy
+++ b/troxy-core/src/test/java/no/sb1/troxy/util/test-recording-with-extra-headers.troxy
@@ -1,0 +1,101 @@
+This is a Troxy recording file.
+You can modify this file in your editor of choice, but there are some rules you must follow:
+* All fields except "COMMENT", "HEADER" and "CONTENT" must stay in one line.
+* Everything after "=" for the fields will be included (text won't be trimmed), this includes whitespace.
+* The "[COMMENT<_END>]", "[HEADER<_END>]" and "[CONTENT<_END>]" markers must be the only text on their lines.
+* If the comment contains "[COMMENT_END]", this must be escaped as "[[COMMENT_END]]".
+* If the header contains "[HEADER_END]", this must be escaped as "[[HEADER_END]]".
+* If the content contains "[CONTENT_END]", this must be escaped as "[[CONTENT_END]]".
+* Any text outside a field will be ignored, and erased if recording is modified in the user interface.
+
+---RECORDING---
+[COMMENT]
+
+[COMMENT_END]
+RESPONSE_STRATEGY=SEQUENTIAL
+
+---REQUEST---
+PROTOCOL=^https$
+HOST=^.*$
+PORT=^443$
+PATH=^/example$
+QUERY=^$
+METHOD=^POST$
+[HEADER]
+^Accept: .*
+Authorization: .*
+Cache-Control: .*
+Connection: .*
+Content-Length: .*
+Content-Type: .*
+Dingo: "straya mate".*
+Host: .*
+Pragma: .*
+SOAPAction: "my-soap-action".*
+User-Agent: .*
+X-XLast-Header: true.*$
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_REQUEST---
+PROTOCOL=https
+HOST=www.example.com
+PORT=443
+PATH=/example
+QUERY=
+METHOD=POST
+[HEADER]
+Accept: */*
+Authorization: Basic authorization
+Cache-Control: no-cache
+Connection: close
+Content-Length: 1850
+Content-Type: text/xml; charset=UTF-8
+Cookie: delicious-cookie
+Forwarded: forwarded-for
+Host: host
+Pragma: no-cache
+SOAPAction: "my-soap-action"
+User-Agent: User-Agent iOS
+X-CACHE-BALANCE-HEADER: cache-balance-header
+X-Forwarded-For: 12.123.123.12
+X-Forwarded-Host: forwarded-host
+X-Forwarded-Port: 443
+X-Forwarded-Proto: https
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---RESPONSE---
+DELAY_STRATEGY=NONE
+DELAY_MIN=0
+DELAY_MEAN=0
+DELAY_MAX=0
+WEIGHT=1
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 1 Jan 1970 00:00:00 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_RESPONSE---
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 26 Oct 2020 12:58:54 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]

--- a/troxy-core/src/test/java/no/sb1/troxy/util/test-recording.troxy
+++ b/troxy-core/src/test/java/no/sb1/troxy/util/test-recording.troxy
@@ -1,0 +1,99 @@
+This is a Troxy recording file.
+You can modify this file in your editor of choice, but there are some rules you must follow:
+* All fields except "COMMENT", "HEADER" and "CONTENT" must stay in one line.
+* Everything after "=" for the fields will be included (text won't be trimmed), this includes whitespace.
+* The "[COMMENT<_END>]", "[HEADER<_END>]" and "[CONTENT<_END>]" markers must be the only text on their lines.
+* If the comment contains "[COMMENT_END]", this must be escaped as "[[COMMENT_END]]".
+* If the header contains "[HEADER_END]", this must be escaped as "[[HEADER_END]]".
+* If the content contains "[CONTENT_END]", this must be escaped as "[[CONTENT_END]]".
+* Any text outside a field will be ignored, and erased if recording is modified in the user interface.
+
+---RECORDING---
+[COMMENT]
+
+[COMMENT_END]
+RESPONSE_STRATEGY=SEQUENTIAL
+
+---REQUEST---
+PROTOCOL=^https$
+HOST=^.*$
+PORT=^443$
+PATH=^/example$
+QUERY=^$
+METHOD=^POST$
+[HEADER]
+^Accept: .*
+Authorization: .*
+Cache-Control: .*
+Connection: .*
+Content-Length: .*
+Content-Type: .*
+Host: .*
+Pragma: .*
+SOAPAction: "my-soap-action".*
+User-Agent: .*$
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_REQUEST---
+PROTOCOL=https
+HOST=www.example.com
+PORT=443
+PATH=/example$
+QUERY=
+METHOD=POST
+[HEADER]
+Accept: */*
+Authorization: Basic authorization
+Cache-Control: no-cache
+Connection: close
+Content-Length: 1850
+Content-Type: text/xml; charset=UTF-8
+Cookie: delicious-cookie
+Forwarded: forwarded-for
+Host: host
+Pragma: no-cache
+SOAPAction: "my-soap-action"
+User-Agent: User-Agent iOS
+X-CACHE-BALANCE-HEADER: cache-balance-header
+X-Forwarded-For: 12.123.123.12
+X-Forwarded-Host: forwarded-host
+X-Forwarded-Port: 443
+X-Forwarded-Proto: https
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---RESPONSE---
+DELAY_STRATEGY=NONE
+DELAY_MIN=0
+DELAY_MEAN=0
+DELAY_MAX=0
+WEIGHT=1
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 1 Jan 1970 00:00:00 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]
+
+---ORIGINAL_RESPONSE---
+CODE=200
+[HEADER]
+X-Forwarded-Proto: https
+Connection: close
+Content-Length: 13943
+Date: Mon, 26 Oct 2020 12:58:54 GMT
+Content-Type: text/xml;charset=utf-8
+[HEADER_END]
+[CONTENT]
+<>Content</>
+[CONTENT_END]


### PR DESCRIPTION
AutoRegexNewRecording currently matches an entire request header against one, gigantic RegEx which is created by concatenating all RegExes in the config. This makes it hard to reason about how one RegEx may behave when concatenated with several others.

This commit changes how AutoRegexNewRecording to matching each pattern separately, line by line. Since the format of a HTTP header is well defined, this should not cause any issues. As a nice side effect, the RegExes specified in the config no longer have to deal with newlines. The changes to AutoRegexNewRecording do not change how the cache is searched, so existing recordings should continue to work without problems.