### PR TITLE
Recorded mocks for requests does not match by default if they have em…

### DIFF
--- a/filter/src/main/java/no/sb1/troxy/filter/KeepRegexNewRecording.java
+++ b/filter/src/main/java/no/sb1/troxy/filter/KeepRegexNewRecording.java
@@ -135,7 +135,7 @@ public class KeepRegexNewRecording extends Filter {
         }
 
         // add back "^" and "$"
-        output = "^.*?" + output;
+        output = "^.*" + output;
         if (!output.endsWith("$"))
             output += "$";
         return output;


### PR DESCRIPTION
…pty body. Change to greedy regex to change this behaviour and allow empty body in requests.